### PR TITLE
Fix a potential wrong operator bug

### DIFF
--- a/src/filetransfers_window.py
+++ b/src/filetransfers_window.py
@@ -416,7 +416,7 @@ _('Connection with peer cannot be established.'))
 		''' add extra spaces from both sides of the percent, so that
 		progress string has always a fixed size'''
 		_str = '          '
-		if percent != 100.:
+		if percent < 100.:
 			_str += ' '
 		if percent < 10:
 			_str += ' '


### PR DESCRIPTION
Hi,

This pull request is a fix to a potential wrong operator bug at `src/filetransfers_window.py`. Please check the changes.

`<` is a better option when `percent` is `1XX%`.

Best,
Jingxuan